### PR TITLE
Fixed DDEX order book fetching when no orders on one of the sides

### DIFF
--- a/exchanges/DDEX.js
+++ b/exchanges/DDEX.js
@@ -38,10 +38,6 @@ module.exports = class DDEX extends OrderBookExchange {
 
         const { asks, bids } = symbol === 'DAI' ? DDEX._flipBook(orderBook) : orderBook
 
-        if (!asks.length || !bids.length) {
-          throw new Error()
-        }
-
         const formattedAsks = asks.map(walkBook)
 
         lotPrice = 0


### PR DESCRIPTION
If no orders on one of the order book sides, `!xxx.length` was returning true and the query always failed, even though the query could still be fulfilled with orders on the other side of the orderbook.

At this moment, a good example is the `WBTC-WETH` book which has zero asks. After this fix at least a WBTC sell query will be successful.