### PR TITLE
Fixed DDEX `WETH-TUSD`, `WETH-USDC`, `WETH-USDT` and `WETH-PAX` books

### DIFF
--- a/exchanges/DDEX.js
+++ b/exchanges/DDEX.js
@@ -2,6 +2,8 @@ const rp = require('request-promise')
 const { DDEX_URL } = require('../constants.js')
 const OrderBookExchange = require('./OrderBookExchange.js')
 
+const flippableBooks = ['DAI', 'TUSD', 'USDC', 'USDT', 'PAX']
+
 module.exports = class DDEX extends OrderBookExchange {
   constructor() {
     super()
@@ -12,7 +14,7 @@ module.exports = class DDEX extends OrderBookExchange {
   // fetch the raw order book from the exchange
   _getRawOrderBook(symbol) {
     let uri = `${this.url}/${symbol}-WETH/orderbook?level=2`
-    if (symbol === 'DAI') {
+    if (flippableBooks.includes(symbol)) {
       uri = `${this.url}/WETH-${symbol}/orderbook?level=2`
     }
     const config = {
@@ -36,7 +38,7 @@ module.exports = class DDEX extends OrderBookExchange {
           data: { orderBook },
         } = await this._getRawOrderBook(symbol)
 
-        const { asks, bids } = symbol === 'DAI' ? DDEX._flipBook(orderBook) : orderBook
+        const { asks, bids } = flippableBooks.includes(symbol) ? DDEX._flipBook(orderBook) : orderBook
 
         if (!asks.length || !bids.length) {
           throw new Error()


### PR DESCRIPTION
`WETH-[TUSD|USDC|USDT|PAX]` DDEX markets are, similarly to `DAI`, not denominated in `WETH` but in TUSD/USDC/USDT/PAX accordingly. But the logic before this patch only handled flipping the book for DAI.

This patch fixes querying DDEX for `TUSD`, `USDC`, `USDT` and `PAX`.