### PR TITLE
Fixed support for RadarRelay markets which didn't fit on the first page

### DIFF
--- a/exchanges/RadarRelay.js
+++ b/exchanges/RadarRelay.js
@@ -9,10 +9,10 @@ module.exports = class RadarRelay extends OrderBookExchange {
     this.name = 'Radar Relay'
   }
 
-  getAvailableMarkets() {
+  _getMarketDetails(marketId) {
     const config = {
       timeout: 3000,
-      uri: this.marketsUrl,
+      uri: `${this.marketsUrl}/${marketId}`,
       method: 'GET',
       json: true,
     }
@@ -58,12 +58,12 @@ module.exports = class RadarRelay extends OrderBookExchange {
 
     return new Promise(async resolve => {
       try {
-        const availableMarkets = await this.getAvailableMarkets()
         const marketId = symbol === 'DAI' ? 'WETH-DAI' : `${symbol}-WETH`
-        const isTokenAvailable = !!availableMarkets.find(market => market.id === marketId)
-        if (!isTokenAvailable) {
+        const marketDetails = await this._getMarketDetails(marketId)
+        if (!marketDetails.active) {
           throw new Error(`${marketId} is not available on ${this.name}`)
         }
+
         const book = await this._getRawOrderBook(marketId)
         const { asks, bids } = symbol === 'DAI' ? RadarRelay._flipBook(book) : book
 

--- a/exchanges/RadarRelay.js
+++ b/exchanges/RadarRelay.js
@@ -21,8 +21,7 @@ module.exports = class RadarRelay extends OrderBookExchange {
   }
 
   // fetch the raw order book from the exchange
-  _getRawOrderBook(symbol) {
-    const marketId = symbol === 'DAI' ? 'WETH-DAI' : `${symbol}-WETH`
+  _getRawOrderBook(marketId) {
     const config = {
       timeout: 3000,
       uri: `${this.marketsUrl}/${marketId}/book`,
@@ -65,7 +64,7 @@ module.exports = class RadarRelay extends OrderBookExchange {
         if (!isTokenAvailable) {
           throw new Error(`${marketId} is not available on ${this.name}`)
         }
-        const book = await this._getRawOrderBook(symbol)
+        const book = await this._getRawOrderBook(marketId)
         const { asks, bids } = symbol === 'DAI' ? RadarRelay._flipBook(book) : book
 
         const formattedAsks = asks.map(walkBook)

--- a/exchanges/RadarRelay.js
+++ b/exchanges/RadarRelay.js
@@ -25,7 +25,7 @@ module.exports = class RadarRelay extends OrderBookExchange {
     const marketId = symbol === 'DAI' ? 'WETH-DAI' : `${symbol}-WETH`
     const config = {
       timeout: 3000,
-      uri: `${this.marketsUrl}/${marketId.toLowerCase()}/book`,
+      uri: `${this.marketsUrl}/${marketId}/book`,
       method: 'GET',
       json: true,
     }


### PR DESCRIPTION
The first thing the RadarRelay client used to do was querying the list of all markets (https://api.radarrelay.com/v2/markets) and looking for our market in it. This approach wasn't giving correct results as the markets list is paged, and most of markets do not fit on the first page with the default `perPage=20`. Increasing `perPage` itself wasn't a solution as the maximum value of this parameter in the RadarRelay API is `100`, but the total number of markets is greater than that.

Instead of that I decided to query the individual market to verify its existence. This way paging isn't an issue anymore.

With this fix, `WBTC-WETH` is now handled correctly.