### PR TITLE
`WBTC` removed from the IDEX quote list. `EURS` added.

### DIFF
--- a/exchanges/IDEX.js
+++ b/exchanges/IDEX.js
@@ -2,7 +2,7 @@ const rp = require('request-promise')
 const { IDEX_URL } = require('../constants.js')
 const OrderBookExchange = require('./OrderBookExchange.js')
 
-const quoteSymbols = ['WBTC', 'TUSD', 'USDC', 'DAI']
+const quoteSymbols = ['TUSD', 'USDC', 'EURS', 'DAI']
 
 module.exports = class IDEX extends OrderBookExchange {
   constructor() {


### PR DESCRIPTION
`WBTC` has been removed today from the IDEX quote list. With this fix in place we can still fetch `WBTC` prices.