### PR TITLE
add dynamic token symbol resolver

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -10,6 +10,7 @@ const FORKDELTA_URL = 'https://api.forkdelta.com'
 const AIRSWAP_TOKEN_METADATA_URL = 'https://token-metadata.production.airswap.io'
 const AIRSWAP_HEADLESS_API = 'https://headless.production.airswap.io'
 const SWITCHEO_URL = 'https://api.switcheo.network'
+const COINGECKO_API_URL = 'https://api.coingecko.com/api/v3'
 
 // DDEX charges a 0.3% taker fee
 const DDEX_TAKER_FEE = 0.003
@@ -92,19 +93,27 @@ const ETH2DAI_ABI = [
   {
     name: 'getBuyAmount',
     outputs: [{ name: 'fill_amt', type: 'uint256' }],
-    inputs: [{ name: 'buy_gem', type: 'address' }, { name: 'pay_gem', type: 'address' }, { name: 'pay_amt', type: 'uint256' }],
+    inputs: [
+      { name: 'buy_gem', type: 'address' },
+      { name: 'pay_gem', type: 'address' },
+      { name: 'pay_amt', type: 'uint256' },
+    ],
     constant: true,
     payable: false,
-    type: 'function'
+    type: 'function',
   },
   {
     name: 'getPayAmount',
     outputs: [{ name: 'fill_amt', type: 'uint256' }],
-    inputs: [{ name: 'pay_gem', type: 'address' }, { name: 'buy_gem', type: 'address' }, { name: 'buy_amt', type: 'uint256' }],
+    inputs: [
+      { name: 'pay_gem', type: 'address' },
+      { name: 'buy_gem', type: 'address' },
+      { name: 'buy_amt', type: 'uint256' },
+    ],
     constant: true,
     payable: false,
-    type: 'function'
-  }
+    type: 'function',
+  },
 ]
 
 const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
@@ -163,4 +172,5 @@ module.exports = {
   WETH_ADDRESS,
   WETH_DECIMALS,
   SWITCHEO_URL,
+  COINGECKO_API_URL,
 }

--- a/exchanges/Eth2Dai.js
+++ b/exchanges/Eth2Dai.js
@@ -1,5 +1,5 @@
 const ethers = require('ethers')
-const tokens = require('../tokensBySymbol.json')
+const { tokenSymbolResolver } = require('../tokenSymbolResolver.js')
 const { ETH2DAI_ABI, ETH2DAI_ADDRESS, WETH_ADDRESS, WETH_DECIMALS } = require('../constants.js')
 
 const { utils } = ethers
@@ -9,13 +9,6 @@ module.exports = class Eth2Dai {
     this.ethProvider = ethers.getDefaultProvider('homestead')
     this.exchangeContract = new ethers.Contract(ETH2DAI_ADDRESS, ETH2DAI_ABI, this.ethProvider)
     this.name = 'Eth2Dai'
-  }
-
-  static getTokenMetadata(symbol) {
-    if (tokens[symbol]) {
-      return tokens[symbol]
-    }
-    throw new Error(`no token metadata available for ${symbol}, can't get decimals`)
   }
 
   async computePrice(symbol, desiredAmount, isSell) {
@@ -28,7 +21,7 @@ module.exports = class Eth2Dai {
         throw new Error('only DAI is supported on ETH2DAI at the moment')
       }
 
-      const { addr, decimals } = Eth2Dai.getTokenMetadata(symbol)
+      const { addr, decimals } = await tokenSymbolResolver(symbol)
 
       const desiredAmountInWei = utils.parseUnits(desiredAmount.toString(), decimals)
       const totalPriceInWei = isSell

--- a/exchanges/Forkdelta.js
+++ b/exchanges/Forkdelta.js
@@ -8,7 +8,7 @@ const Tx = require('ethereumjs-tx')
 
 const { FORKDELTA_URL } = require('../constants.js')
 const OrderBookExchange = require('./OrderBookExchange.js')
-const tokens = require('../tokensBySymbol.json')
+const { tokenSymbolResolver } = require('../tokenSymbolResolver.js')
 
 module.exports = class Forkdelta extends OrderBookExchange {
   constructor() {
@@ -19,20 +19,13 @@ module.exports = class Forkdelta extends OrderBookExchange {
     this.name = 'Forkdelta'
   }
 
-  static getTokenMetadata(symbol) {
-    if (tokens[symbol]) {
-      return tokens[symbol]
-    }
-    throw new Error(`${symbol} not available on Forkdelta`)
-  }
-
   async _createCanonicalOrderBook(symbol) {
     let lotPrice = 0
     let lotAmount = 0
 
     return new Promise(async resolve => {
       try {
-        const { addr } = Forkdelta.getTokenMetadata(symbol)
+        const { addr } = await tokenSymbolResolver(symbol)
 
         this.service
           .init({

--- a/exchanges/Uniswap.js
+++ b/exchanges/Uniswap.js
@@ -1,6 +1,6 @@
 const tokenAbi = require('human-standard-token-abi')
 const ethers = require('ethers')
-const tokens = require('../tokensBySymbol.json')
+const { tokenSymbolResolver } = require('../tokenSymbolResolver.js')
 const { UNISWAP_FACTORY_ABI, UNISWAP_FACTORY_ADDRESS } = require('../constants.js')
 
 const { utils } = ethers
@@ -40,13 +40,6 @@ module.exports = class Uniswap {
     return { ethAmount, tokenAmount }
   }
 
-  static getTokenMetadata(symbol) {
-    if (tokens[symbol]) {
-      return tokens[symbol]
-    }
-    throw new Error(`no token metadata available for ${symbol}, can't get decimals`)
-  }
-
   static getBuyRate(tokenAmountBought, inputReserve, outputReserve) {
     const numerator = tokenAmountBought * inputReserve * 1000
     const denominator = (outputReserve - tokenAmountBought) * 997
@@ -63,7 +56,7 @@ module.exports = class Uniswap {
   async computePrice(symbol, desiredAmount, isSell) {
     let result = {}
     try {
-      const { addr, decimals } = Uniswap.getTokenMetadata(symbol)
+      const { addr, decimals } = await tokenSymbolResolver(symbol)
       const { ethAmount, tokenAmount } = await this.getExchangeLiquidityByAddress(symbol, addr, decimals)
 
       // Any BNB sent to Uniswap will be lost forever

--- a/tokenSymbolResolver.js
+++ b/tokenSymbolResolver.js
@@ -1,0 +1,51 @@
+// service responsible for resolving symbols to ethereum addresses
+const rp = require('request-promise')
+
+const { COINGECKO_API_URL, AIRSWAP_TOKEN_METADATA_URL } = require('./constants.js')
+const jsonTokensBySymbol = require('./tokensBySymbol.json')
+
+// Returns a promise that will always resolve()
+// will resolve with a string `tokenAddress` or `undefined`
+// e.g. tokenSymbolResolver('DAI') -> "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"
+// tokenSymbolResolver('FizzBuzz') -> undefined
+const tokenSymbolResolver = async symbol => {
+  let tokenAddress = null
+  try {
+    // first, query coingecko api and try to resolve dynamically
+    tokenAddress = await new Promise(async (resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('5s timeout reached waiting for Coingecko API'))
+      }, 5000)
+
+      try {
+        // get all tokens and find by relevant symbol
+        const cgTokensList = JSON.parse(await rp(`${COINGECKO_API_URL}/coins/list`))
+        const matchedTokenObj = cgTokensList.find(tokenObj => tokenObj.symbol.toUpperCase() === symbol.toUpperCase())
+        if (!matchedTokenObj) throw new Error(`${symbol} not found in coingecko api`)
+        const matchedTokenMetadata = JSON.parse(await rp(`${COINGECKO_API_URL}/coins/${matchedTokenObj.id}`))
+        if (!matchedTokenMetadata.contract_address) throw new Error(`${symbol} not found in coingecko api`)
+
+        // get decimals using airswap api
+        const { decimals } = JSON.parse(
+          await rp(`${AIRSWAP_TOKEN_METADATA_URL}/crawlTokenData?address=${matchedTokenMetadata.contract_address}`),
+        )
+
+        // resolve with token address and decimals
+        resolve({ addr: matchedTokenMetadata.contract_address, decimals })
+      } catch (e) {
+        reject(e)
+      } finally {
+        // clean up event loop
+        global.clearTimeout(timeout)
+      }
+    })
+  } catch (e) {
+    console.log('error while resolving symbol with CoinGecko API:', e.message)
+    console.log('falling back to static token metadata')
+    tokenAddress = jsonTokensBySymbol[symbol]
+  }
+
+  return tokenAddress
+}
+
+module.exports = { tokenSymbolResolver }


### PR DESCRIPTION
This PR introduces dynamic symbol resolution for DEX's that need to know a token's address and/or decimals. This is accomplished through a soft dependency on the free CoinGecko API and the free AirSwap API. Previously, the service relied on a large number of static local metadata files to get data about a token's address or decimals (via https://github.com/forkdelta/tokenbase).

These static local metadata files still exist in the service, but they are now used only as a fallback if the CoinGecko + AirSwap metadata network requests fail for some reason.