### PR TITLE
Fixed fee calculation for sells

### DIFF
--- a/exchanges/OrderBookExchange.js
+++ b/exchanges/OrderBookExchange.js
@@ -76,7 +76,7 @@ module.exports = class OrderBookExchange {
       }
     }
     if (fee !== 0) {
-      result = applyFeeToResult(result, fee)
+      result = applyFeeToResult(result, fee, isSell)
     }
     return { [this.name]: result }
 

--- a/helpers.js
+++ b/helpers.js
@@ -38,10 +38,11 @@ module.exports = {
     }
     console.log(sortedResults)
   },
-  applyFeeToResult(result, fee) {
+  applyFeeToResult(result, fee, isSell) {
     const { totalPrice, tokenAmount } = result
-    const newTotalPrice = totalPrice + totalPrice * fee
+    const newTotalPrice = isSell ? totalPrice - (totalPrice * fee) : totalPrice + (totalPrice * fee)
     const newAveragePrice = newTotalPrice / tokenAmount
+    console.log(`Fee applied! old total price: ${totalPrice}; new price: ${newTotalPrice}`)
     return { ...result, totalPrice: newTotalPrice, avgPrice: newAveragePrice }
   },
 }


### PR DESCRIPTION
Fees are not currently being calculated correctly for sell calls. 

The fee is currently added to the total ETH involved in the trade for both buys and sells. For buys, this is correct, as the fee would increase the amount of ETH required to purchase the given token amount. For sells, this overstates your ETH proceeds by ( (fee * 2) * unadjusted proceeds ), making the trade appear more attractive than it actually is.